### PR TITLE
Fix a link to the Github site that was incorrect

### DIFF
--- a/modules/responses.py
+++ b/modules/responses.py
@@ -63,4 +63,4 @@ def botversion(bot, trigger):
 @rate(user=2, channel=1, server=0)
 def githubsource(bot, trigger):
     """Give the link to ZppixBot's Github."""
-    bot.reply('My code can be found here: https://github.com/Pix1234/ZppixBot-Source')
+    bot.reply('My code can be found here: https://github.com/MirahezeBots/MirahezeBots')


### PR DESCRIPTION
Today, when trying to find the source for this bot, I stumbled across a link to a repository that was no longer in use. I created this commit to fix that.