### PR TITLE
Redesign requirements & add CI for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ script:
     - pytest tests/test_rss.py
     - pip check
     - flake8 tests --ignore E402,F401,W503,E722 --max-line-length 220
+    - pip-missing-reqs --ignore-file=setup.py --ignore-module=pytest --ignore-module=MirahezeBots.* .
+    - pip-extra-reqs .
 
 deploy:
   provider: pypi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 # Development requirements
 vcrpy==4.0.2
 six==1.15.0
+pip-check-reqs==2.1.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,5 @@
 vcrpy==4.0.2
 six==1.15.0
 pip-check-reqs==2.1.1
+setuptools==49.2.0
+pytest==5.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # dependenices used in test ZppixBot
-configparser==5.0.0
 feedparser==5.2.1
 mwclient==0.10.1
 requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,7 @@
 # dependenices used in test ZppixBot
-certifi==2020.6.20
 configparser==5.0.0
 feedparser==5.2.1
 mwclient==0.10.1
-pytz==2020.1
-PyYAML==5.3.1
 requests==2.24.0
-requests-oauthlib==1.3.0
 sopel>=7.0.5,<8
 SQLAlchemy==1.3.18
-update-checker==0.17
-xmltodict==0.12.0


### PR DESCRIPTION
Add (dev):
pip-check-reqs==2.1.1
setuptools==49.2.0
pytest==5.4.3

Remove (main):
certifi==2020.6.20
configparser==5.0.0
pytz==2020.1
requests-oauthlib==1.3.0
update-checker==0.17
xmltodict==0.12.0

And add CI checks to check requirements are valid