### PR TITLE
status: stop parsing trigger in updatestatus

### DIFF
--- a/MirahezeBots/plugins/status.py
+++ b/MirahezeBots/plugins/status.py
@@ -44,22 +44,22 @@ def updatestatus(bot, options):
             request = [user, status]
             cont = 1
             break
-        if cont == 0:
-            usersfile = open(bot.config.status.data_path + 'users.csv', 'r')
-            for line in usersfile:
-                auth = line.split(',')
-                if str(trigger.account) == auth[0]:
-                    user = auth[1]
-                    sulgroup = auth[2]
-                    wiki = [wiki, sulgroup]
-                    request = [user, status]
-                    cont = 1
-                    break
-        if cont == 0:
-            message = "You don't seem to be authorised to use this module. Please check you are signed into NickServ and try again."
-            if bot.config.status.support_channel is not None:
-                message = message + " If this persists, ask for help in {}".format(bot.config.status.support_channel)
-            return message
+    if cont == 0:
+        usersfile = open(bot.config.status.data_path + 'users.csv', 'r')
+        for line in usersfile:
+            auth = line.split(',')
+            if str(trigger.account) == auth[0]:
+                user = auth[1]
+                sulgroup = auth[2]
+                wiki = [wiki, sulgroup]
+                request = [user, status]
+                cont = 1
+                break
+    if cont == 0:
+        message = "You don't seem to be authorised to use this module. Please check you are signed into NickServ and try again."
+        if bot.config.status.support_channel is not None:
+            message = message + " If this persists, ask for help in {}".format(bot.config.status.support_channel)
+        return message
     if cont == 1:
         wikiurl = 'example.org'
         wikiexists = 0

--- a/MirahezeBots/plugins/status.py
+++ b/MirahezeBots/plugins/status.py
@@ -32,15 +32,15 @@ def configure(config):
     config.status.configure_setting('support_channel', 'Specify a support IRC channel (leave blank for none).')
 
 
-def updatestatus(bot, options):
+def updatestatus(bot, requestdata):
     cont = 0
     cloakfile = open(bot.config.status.data_path + 'cloaks.csv', 'r')
     for line in cloakfile:
         auth = line.split(',')
-        if host[0] == auth[0]:
-            user = host[1]
+        if requestdata[1][0] == auth[0]:
+            user = requestdata[1][1]
             sulgroup = auth[1]
-            wiki = [wiki, sulgroup]
+            wiki = [requestdata[2], sulgroup]
             request = [user, status]
             cont = 1
             break
@@ -48,7 +48,7 @@ def updatestatus(bot, options):
         usersfile = open(bot.config.status.data_path + 'users.csv', 'r')
         for line in usersfile:
             auth = line.split(',')
-            if str(trigger.account) == auth[0]:
+            if requestdata[1][0] == auth[0]:
                 user = auth[1]
                 sulgroup = auth[2]
                 wiki = [wiki, sulgroup]
@@ -105,12 +105,13 @@ def status(bot, trigger):
         else:
             bot.reply("Syntax: .status wikicode new-status")
             cont = 0
-    except AtributeError as e:
+    except AttributeError as e:
         bot.reply("Syntax: .status wikicode new-status")
         bot.say("AttributeError: {} from Status plugin in {}".format(e, trigger.sender), bot.config.core.logging_channel)
         cont = 0
     if cont == 1:
-        response = updatestatus(bot, options)
+        requestdata = [str(trigger.account), host, wiki]
+        response = updatestatus(bot, requestdata)
         if response == "create request sent. You may want to check the create log to be sure that it worked.":
             bot.reply("Success")
         else:

--- a/MirahezeBots/plugins/status.py
+++ b/MirahezeBots/plugins/status.py
@@ -34,16 +34,16 @@ def configure(config):
 
 def updatestatus(bot, options):
     cont = 0
-        cloakfile = open(bot.config.status.data_path + 'cloaks.csv', 'r')
-        for line in cloakfile:
-            auth = line.split(',')
-            if host[0] == auth[0]:
-                user = host[1]
-                sulgroup = auth[1]
-                wiki = [wiki, sulgroup]
-                request = [user, status]
-                cont = 1
-                break
+    cloakfile = open(bot.config.status.data_path + 'cloaks.csv', 'r')
+    for line in cloakfile:
+        auth = line.split(',')
+        if host[0] == auth[0]:
+            user = host[1]
+            sulgroup = auth[1]
+            wiki = [wiki, sulgroup]
+            request = [user, status]
+            cont = 1
+            break
         if cont == 0:
             usersfile = open(bot.config.status.data_path + 'users.csv', 'r')
             for line in usersfile:

--- a/MirahezeBots/plugins/status.py
+++ b/MirahezeBots/plugins/status.py
@@ -32,31 +32,9 @@ def configure(config):
     config.status.configure_setting('support_channel', 'Specify a support IRC channel (leave blank for none).')
 
 
-def updatestatus(bot, trigger, options):
+def updatestatus(bot, options):
     cont = 0
-    if len(options) == 2:
-        wiki = options[0]
-        status = options[1]
-        host = trigger.host
-        host = host.split('/')
-        cont = 1
-    elif len(options) > 2:
-        wiki = options[0]
-        host = trigger.host
-        host = host.split('/')
-        status = options[1]
-        x = 2
-        while x < len(options):
-            status = status + " " + options[x]
-            x = x + 1
-        cont = 1
-    else:
-        bot.reply("Syntax: .status wikicode status")
-        cont = 0
-    if cont == 1:
-        cont = 0
-        cloakfile = open(bot.config.status.data_path
-                         + 'cloaks.csv', 'r')
+        cloakfile = open(bot.config.status.data_path + 'cloaks.csv', 'r')
         for line in cloakfile:
             auth = line.split(',')
             if host[0] == auth[0]:
@@ -67,8 +45,7 @@ def updatestatus(bot, trigger, options):
                 cont = 1
                 break
         if cont == 0:
-            usersfile = open(bot.config.status.data_path
-                             + 'users.csv', 'r')
+            usersfile = open(bot.config.status.data_path + 'users.csv', 'r')
             for line in usersfile:
                 auth = line.split(',')
                 if str(trigger.account) == auth[0]:
@@ -106,9 +83,35 @@ def updatestatus(bot, trigger, options):
 @example('.status mhtest offline')
 def status(bot, trigger):
     """Update's the /Status subpage of Special:MyPage on the indicated wiki"""
-    options = trigger.group(2).split(" ")
-    response = updatestatus(bot, trigger, options)
-    if response == "create request sent. You may want to check the create log to be sure that it worked.":
-        bot.reply("Success")
-    else:
-        bot.reply(str(response))
+    options = []
+    try:
+        options = trigger.group(2).split(" ")
+        if len(options) == 2:
+            wiki = options[0]
+            status = options[1]
+            host = trigger.host
+            host = host.split('/')
+            cont = 1
+        elif len(options) > 2:
+            wiki = options[0]
+            host = trigger.host
+            host = host.split('/')
+            status = options[1]
+            x = 2
+            while x < len(options):
+                status = status + " " + options[x]
+                x = x + 1
+            cont = 1
+        else:
+            bot.reply("Syntax: .status wikicode new-status")
+            cont = 0
+    except AtributeError as e:
+        bot.reply("Syntax: .status wikicode new-status")
+        bot.say("AttributeError: {} from Status plugin in {}".format(e, trigger.sender), bot.config.core.logging_channel)
+        cont = 0
+    if cont == 1:
+        response = updatestatus(bot, options)
+        if response == "create request sent. You may want to check the create log to be sure that it worked.":
+            bot.reply("Success")
+        else:
+            bot.reply(str(response))


### PR DESCRIPTION
This drops the trigger.* and options from being passed to the updatestatus(..) method and replaces it with a requestdata array containing the data for the request. By doing this, we ensure that the passed data to updatestatus is validated and can better handle exceptions.

Bug: T61